### PR TITLE
chore(workspace): bump version to 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cli_docs_macro", "cobblepot"]
 
 [workspace.package]
 name = "cobblepot"
-version = "0.2.0"
+version = "0.2.1"
 description = "Cobblepot: A self-hosted personal finance server & CLI for tracking accounts, balances, reports, and recurring transactions."
 edition = "2024"
 authors = ["Cesar Diaz"]

--- a/cobblepot/Cargo.toml
+++ b/cobblepot/Cargo.toml
@@ -10,10 +10,10 @@ actix-web = "4.11.0"
 chrono = { version = "0.4.41", features = ["serde"] }
 derive_more = { version = "2.0.1", features = ["display", "error"] }
 diesel = { version = "2.2.10", features = [
-    "chrono",
-    "r2d2",
-    "returning_clauses_for_sqlite_3_35",
-    "sqlite",
+  "chrono",
+  "r2d2",
+  "returning_clauses_for_sqlite_3_35",
+  "sqlite",
 ] }
 diesel_migrations = "2.2.0"
 env_logger = "0.11.8"

--- a/cobblepot/src/recurring_transaction/model.rs
+++ b/cobblepot/src/recurring_transaction/model.rs
@@ -6,6 +6,13 @@ use diesel::prelude::{Identifiable, Insertable, Queryable};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JSONListRecurringTransactions {
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+    pub account_id: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JSONOpenRecurringTransaction {
     pub name: String,
     pub description: Option<String>,
@@ -73,6 +80,18 @@ impl Responder for RecurringTransaction {
         let body = serde_json::to_string(&self).unwrap();
 
         // Create response and set content type
+        HttpResponse::Ok().content_type(ContentType::json()).body(body)
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct RecurringTransactionList(pub Vec<RecurringTransaction>);
+
+impl Responder for RecurringTransactionList {
+    type Body = BoxBody;
+
+    fn respond_to(self, _: &actix_web::HttpRequest) -> actix_web::HttpResponse<Self::Body> {
+        let body = serde_json::to_string(&self.0).unwrap();
         HttpResponse::Ok().content_type(ContentType::json()).body(body)
     }
 }


### PR DESCRIPTION
feat(recurring_transaction): add list endpoint for recurring transactions

- Introduce `JSONListRecurringTransactions` (limit, offset, optional account_id) for query parameters
- Implement `list_recurring_transactions` handler using Diesel’s boxed queries: • Filter by `account_id` when provided • Apply offset and limit (default 0/25)
- Add `RecurringTransactionList` wrapper with `Responder` impl to return JSON arrays
- Expose new GET route `/recurring_transaction/list`