### PR TITLE
feat/markets

### DIFF
--- a/cobblepot/src/balance/model.rs
+++ b/cobblepot/src/balance/model.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::{schema::balance, shared::responder::impl_json_responder};
 use actix_web::{HttpRequest, HttpResponse, Responder, body::BoxBody, http::header::ContentType};
 use chrono::{DateTime, NaiveDateTime, Utc};
@@ -25,6 +27,8 @@ pub struct JSONOpenBalance {
     pub entered_on: Option<DateTime<Utc>>,
     pub account_id: i32,
 }
+
+pub type JSONBatchOpenBalance = HashMap<i32, JSONOpenBalance>;
 
 /// Represents the JSON payload for updating an existing balance record.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/cobblepot/src/financial_market/model.rs
+++ b/cobblepot/src/financial_market/model.rs
@@ -130,6 +130,7 @@ pub struct CalculatedMarketInstrument {
     pub total_value: f64,
 }
 
+/// Total Value is always defaults to 0. Make sure to overwrite it
 impl From<MarketInstrument> for CalculatedMarketInstrument {
     fn from(value: MarketInstrument) -> Self {
         Self {
@@ -137,7 +138,7 @@ impl From<MarketInstrument> for CalculatedMarketInstrument {
             name: value.name,
             ticker: value.ticker,
             market: value.market,
-            instrument_type: InstrumentType::Stock,
+            instrument_type: InstrumentType::from(value.instrument_type),
             quantity: value.quantity,
             opened_on: Utc::now(),
             account_id: value.account_id,


### PR DESCRIPTION
Add JSONBatchOpenBalance (HashMap<i32, JSONOpenBalance>) and a new POST /balance/open-batch endpoint to insert multiple opening balances in one call. This reduces round-trips when initializing several accounts at once.

Also fix CalculatedMarketInstrument::from(MarketInstrument) to derive instrument_type from the source value instead of defaulting to Stock, ensuring correct typing for non-stock instruments. Add a note that total_value defaults to 0 and should be overwritten by callers.