### PR TITLE
Add CLI update commands and centralize budget recurrence handling

### DIFF
--- a/cli/src/create_command/dto.rs
+++ b/cli/src/create_command/dto.rs
@@ -1,8 +1,7 @@
-use crate::shared::AccountType;
+use crate::shared::{AccountType, create_budget_recurrence};
 use chrono::Local;
 use cobblepot_data_store::{RecurrenceRule, UnixTimestamp};
 use diesel::{Connection, Insertable, QueryResult, SqliteConnection};
-use rrule::Tz;
 
 /// Represents a new account to be inserted into the database.
 #[derive(Debug, Insertable)]
@@ -93,16 +92,6 @@ struct NewBudget {
     budget_recurrence_id: Option<i32>,
 }
 
-#[derive(Debug, Insertable)]
-#[diesel(check_for_backend(Sqlite))]
-#[diesel(table_name=cobblepot_data_store::schema::budget_recurrence)]
-struct NewBudgetRecurrence {
-    dt_start: UnixTimestamp,
-    recurrence_rule: RecurrenceRule,
-    budget_id: Option<i32>,
-    budget_item_id: Option<i32>,
-}
-
 pub fn create_new_budget(
     mut conn: SqliteConnection,
     name: String,
@@ -110,53 +99,32 @@ pub fn create_new_budget(
     anticipated_amount: f32,
     r_rule: Option<(chrono::NaiveDateTime, String)>,
 ) -> QueryResult<(i32, String)> {
-    use cobblepot_data_store::{
-        Budget, BudgetRecurrence,
-        schema::{budget, budget_recurrence},
-    };
+    use cobblepot_data_store::{Budget, schema::budget};
     use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl, dsl::insert_into};
-    match r_rule {
-        Some((dt_start, unvalidated_str)) => conn.transaction(|conn| {
-            let mut unvalidated_rrule = RecurrenceRule::new(unvalidated_str);
-            let rrule_dt_start = dt_start.clone().and_local_timezone(Tz::UTC).unwrap();
-            let validated: RecurrenceRule = unvalidated_rrule
-                .validate(rrule_dt_start)
-                .inspect_err(|e| log::error!("Could not validate rrule: {:?}", e))
-                .expect("Invalid rrule")
-                .into();
-            let res = insert_into(budget::table)
-                .values(NewBudget {
-                    name,
-                    description,
-                    anticipated_amount,
-                    budget_recurrence_id: None,
-                })
-                .get_result::<Budget>(conn)?;
-            let b_recurrence = insert_into(budget_recurrence::table)
-                .values(NewBudgetRecurrence {
-                    dt_start: UnixTimestamp::new(dt_start),
-                    recurrence_rule: validated,
-                    budget_id: Some(res.id),
-                    budget_item_id: None,
-                })
-                .get_result::<BudgetRecurrence>(conn)?;
+
+    conn.transaction(|conn| {
+        let res = insert_into(budget::table)
+            .values(NewBudget {
+                name,
+                description,
+                anticipated_amount,
+                budget_recurrence_id: None,
+            })
+            .get_result::<Budget>(conn)?;
+        if let Some((dt_start, unvalidated_str)) = r_rule {
+            let rec_id = create_budget_recurrence(
+                conn,
+                UnixTimestamp::new(dt_start),
+                RecurrenceRule::new(unvalidated_str),
+                Some(res.id),
+                None,
+            )?;
             diesel::update(budget::table.filter(budget::id.eq(res.id)))
-                .set(budget::budget_recurrence_id.eq(b_recurrence.id))
+                .set(budget::budget_recurrence_id.eq(rec_id))
                 .execute(conn)?;
-            Ok((res.id, res.name))
-        }),
-        None => conn.transaction(|conn| {
-            let res = insert_into(budget::table)
-                .values(NewBudget {
-                    name,
-                    description,
-                    anticipated_amount,
-                    budget_recurrence_id: None,
-                })
-                .get_result::<Budget>(conn)?;
-            Ok((res.id, res.name))
-        }),
-    }
+        }
+        Ok((res.id, res.name))
+    })
 }
 
 #[derive(Debug, Insertable)]
@@ -178,56 +146,33 @@ pub fn create_new_budget_item(
     r_rule: Option<(chrono::NaiveDateTime, String)>,
     budget_id: i32,
 ) -> QueryResult<(i32, String)> {
-    use cobblepot_data_store::{
-        BudgetItem, BudgetRecurrence,
-        schema::{budget_item, budget_recurrence},
-    };
+    use cobblepot_data_store::{BudgetItem, schema::budget_item};
     use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl, dsl::insert_into};
-    match r_rule {
-        Some((dt_start, unvalidated_str)) => conn.transaction(|conn| {
-            let mut unvalidated_rrule = RecurrenceRule::new(unvalidated_str);
-            let rrule_dt_start = dt_start.clone().and_local_timezone(Tz::UTC).unwrap();
-            let validated: RecurrenceRule = unvalidated_rrule
-                .validate(rrule_dt_start)
-                .inspect_err(|e| log::error!("Could not validate rrule: {:?}", e))
-                .expect("Invalid rrule")
-                .into();
-            let res = insert_into(budget_item::table)
-                .values(NewBudgetItem {
-                    budget_id,
-                    name,
-                    description,
-                    amount,
-                    budget_recurrence_id: None,
-                })
-                .get_result::<BudgetItem>(conn)?;
-            let b_recurrence = insert_into(budget_recurrence::table)
-                .values(NewBudgetRecurrence {
-                    dt_start: UnixTimestamp::new(dt_start),
-                    recurrence_rule: validated,
-                    budget_id: None,
-                    budget_item_id: Some(res.id),
-                })
-                .get_result::<BudgetRecurrence>(conn)?;
 
+    conn.transaction(|conn| {
+        let res = insert_into(budget_item::table)
+            .values(NewBudgetItem {
+                budget_id,
+                name,
+                description,
+                amount,
+                budget_recurrence_id: None,
+            })
+            .get_result::<BudgetItem>(conn)?;
+        if let Some((dt_start, unvalidated_str)) = r_rule {
+            let rec_id = create_budget_recurrence(
+                conn,
+                UnixTimestamp::new(dt_start),
+                RecurrenceRule::new(unvalidated_str),
+                None,
+                Some(res.id),
+            )?;
             diesel::update(budget_item::table.filter(budget_item::id.eq(res.id)))
-                .set(budget_item::budget_recurrence_id.eq(b_recurrence.id))
+                .set(budget_item::budget_recurrence_id.eq(rec_id))
                 .execute(conn)?;
-            Ok((res.id, res.name))
-        }),
-        None => conn.transaction(|conn| {
-            let res = insert_into(budget_item::table)
-                .values(NewBudgetItem {
-                    budget_id,
-                    name,
-                    description,
-                    amount,
-                    budget_recurrence_id: None,
-                })
-                .get_result::<BudgetItem>(conn)?;
-            Ok((res.id, res.name))
-        }),
-    }
+        }
+        Ok((res.id, res.name))
+    })
 }
 
 #[derive(Debug, Insertable)]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3,6 +3,7 @@ mod list_command;
 mod logger;
 mod report_command;
 mod shared;
+mod update_command;
 
 use clap::{Parser, Subcommand};
 use diesel::Connection;
@@ -12,6 +13,7 @@ enum Command {
     List(list_command::ListArgs),
     Create(create_command::CreateArgs),
     Report(report_command::ReportArgs),
+    Update(update_command::UpdateArgs),
 }
 
 #[derive(Debug, clap::Parser)]
@@ -33,6 +35,7 @@ pub fn main() {
         Command::List(list_args) => list_command::handle_list_command(list_args, conn),
         Command::Create(create_args) => create_command::handle_create_command(create_args, conn),
         Command::Report(report_args) => report_command::handle_report_command(report_args, conn),
+        Command::Update(update_args) => update_command::handle_update_command(update_args, conn),
     }
 }
 

--- a/cli/src/report_command/budget.rs
+++ b/cli/src/report_command/budget.rs
@@ -1,11 +1,10 @@
 use crate::{
     inform,
     report_command::dto::{BudgetData, LatestBalanceRow},
-    shared::format_money_usd,
+    shared::{format_money_usd, get_next_occurences, zip_all},
     success,
 };
 use cobblepot_data_store::{RecurrenceRule, UnixTimestamp};
-use rrule::{RRuleResult, RRuleSet};
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -64,10 +63,10 @@ impl BudgetReport {
                 bia.item_recurrence_rule.clone(),
             ) {
                 budget_item_recurrences.entry(bia.item_id).or_insert(BudgetRecurrence {
-                            id,
-                            dt_start,
-                            recurrence_rule,
-                        });
+                    id,
+                    dt_start,
+                    recurrence_rule,
+                });
             };
             if let Some((account_id, allocation_percent)) =
                 bia.account_id.zip(bia.allocation_percentage)
@@ -125,10 +124,10 @@ impl BudgetReport {
         total
     }
 
-    fn display_budget_item_account(&self) {
+    fn display_budget_item_account(&self) -> bool {
         let supporting_account_ids = self.budget_item_accounts.keys();
         if supporting_account_ids.len() == 0 {
-            return;
+            return false;
         }
         success!("Involved Accounts");
         for account_id in supporting_account_ids {
@@ -158,6 +157,7 @@ impl BudgetReport {
                 }
             }
         }
+        return true;
     }
 
     pub fn display(&self) {
@@ -167,33 +167,12 @@ impl BudgetReport {
         let total_amount = self.display_budget_items();
         println!();
         println!();
-        self.display_budget_item_account();
-        println!();
-        println!();
+        if self.display_budget_item_account() {
+            println!();
+            println!();
+        };
         inform!("Total Amount", format_money_usd(total_amount));
     }
-}
-
-fn zip_all<A, B, C>(a: Option<A>, b: Option<B>, c: Option<C>) -> Option<(A, B, C)> {
-    match a.zip(b) {
-        Some(e) => match c {
-            Some(r) => Some((e.0, e.1, r)),
-            None => None,
-        },
-        None => None,
-    }
-}
-
-fn get_next_occurences(
-    rule: rrule::RRule<rrule::Validated>,
-    dt_start: &UnixTimestamp,
-) -> RRuleResult {
-    log::trace!("Starting next occurences {}", rule);
-    let temp_set =
-        RRuleSet::new(dt_start.inner().and_utc().with_timezone(&rrule::Tz::UTC)).rrule(rule);
-    // let temp_set = RRuleSet::from_str(rule.to_string().as_str()).unwrap();
-    let after_now = temp_set.after(chrono::Utc::now().with_timezone(&rrule::Tz::UTC));
-    after_now.all(10)
 }
 
 fn display_recurrence_rule(dt_start: &UnixTimestamp, rule: &RecurrenceRule, amount: f32) {
@@ -209,7 +188,7 @@ fn display_recurrence_rule(dt_start: &UnixTimestamp, rule: &RecurrenceRule, amou
                 let mut next = "   ".to_string();
                 for (index, dt) in next_occurences.dates.iter().enumerate() {
                     let iter = format!(
-                        "{} -> {:<15}",
+                        "{} -> {:<25}",
                         &dt.format("%Y-%m-%d").to_string(),
                         format_money_usd((index as f32 + 1.0) * amount)
                     );

--- a/cli/src/report_command/budget.rs
+++ b/cli/src/report_command/budget.rs
@@ -157,7 +157,7 @@ impl BudgetReport {
                 }
             }
         }
-        return true;
+        true
     }
 
     pub fn display(&self) {

--- a/cli/src/shared.rs
+++ b/cli/src/shared.rs
@@ -1,5 +1,8 @@
 use clap::ValueEnum;
+use cobblepot_data_store::{BudgetRecurrence, RecurrenceRule, UnixTimestamp, schema};
+use diesel::{Insertable, QueryResult, RunQueryDsl, SqliteConnection, dsl::insert_into};
 use num_enum::{FromPrimitive, IntoPrimitive};
+use rrule::{RRuleResult, RRuleSet, Tz};
 use serde::{Deserialize, Serialize};
 
 /// ValueEnum for AccountType
@@ -61,4 +64,68 @@ pub fn format_money_usd(value: f32) -> String {
         ""
     };
     format!("{}${}.{:02}", sign, with_commas, cents)
+}
+
+/// Validates an rrule against a dt_start and returns the validated RecurrenceRule
+pub fn validate_rrule(dt_start: &UnixTimestamp, rrule: &mut RecurrenceRule) -> RecurrenceRule {
+    let rrule_dt_start = dt_start.inner().and_local_timezone(Tz::UTC).unwrap();
+    rrule
+        .validate(rrule_dt_start)
+        .inspect_err(|e| log::error!("Could not validate rrule: {:?}", e))
+        .expect("Invalid rrule")
+        .into()
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(check_for_backend(Sqlite))]
+#[diesel(table_name = schema::budget_recurrence)]
+pub struct NewBudgetRecurrence {
+    pub dt_start: UnixTimestamp,
+    pub recurrence_rule: RecurrenceRule,
+    pub budget_id: Option<i32>,
+    pub budget_item_id: Option<i32>,
+}
+
+/// Creates a new BudgetRecurrence and returns its id
+pub fn create_budget_recurrence(
+    conn: &mut SqliteConnection,
+    dt_start: UnixTimestamp,
+    mut rrule: RecurrenceRule,
+    budget_id: Option<i32>,
+    budget_item_id: Option<i32>,
+) -> QueryResult<i32> {
+    let validated = validate_rrule(&dt_start, &mut rrule);
+
+    let recurrence = insert_into(schema::budget_recurrence::table)
+        .values(NewBudgetRecurrence {
+            dt_start,
+            recurrence_rule: validated,
+            budget_id,
+            budget_item_id,
+        })
+        .get_result::<BudgetRecurrence>(conn)?;
+
+    Ok(recurrence.id)
+}
+
+pub fn zip_all<A, B, C>(a: Option<A>, b: Option<B>, c: Option<C>) -> Option<(A, B, C)> {
+    match a.zip(b) {
+        Some(e) => match c {
+            Some(r) => Some((e.0, e.1, r)),
+            None => None,
+        },
+        None => None,
+    }
+}
+
+pub fn get_next_occurences(
+    rule: rrule::RRule<rrule::Validated>,
+    dt_start: &UnixTimestamp,
+) -> RRuleResult {
+    log::trace!("Starting next occurences {}", rule);
+    let temp_set =
+        RRuleSet::new(dt_start.inner().and_utc().with_timezone(&rrule::Tz::UTC)).rrule(rule);
+    // let temp_set = RRuleSet::from_str(rule.to_string().as_str()).unwrap();
+    let after_now = temp_set.after(chrono::Utc::now().with_timezone(&rrule::Tz::UTC));
+    after_now.all(5)
 }

--- a/cli/src/update_command.rs
+++ b/cli/src/update_command.rs
@@ -1,0 +1,117 @@
+mod dto;
+
+use crate::{alert, success};
+use clap::{Parser, Subcommand};
+use cobblepot_data_store::{RecurrenceRule, UnixTimestamp};
+use diesel::SqliteConnection;
+
+#[derive(Debug, Subcommand)]
+pub enum UpdateCommand {
+    #[clap(about = "Update a budget")]
+    Budget {
+        #[clap(help = "Id of the budget")]
+        id: i32,
+        #[clap(short, long, help = "Name of the budget")]
+        name: Option<String>,
+        #[clap(short, long, help = "Description of the budget")]
+        description: Option<String>,
+        #[clap(short, long, help = "Expected dollar limit")]
+        anticipated_amount: Option<f32>,
+        #[clap(short='s', long, value_parser = crate::shared::parse_date, help = "Date budget recurrence starts (format: YYYY-MM-DD)")]
+        r_start: Option<chrono::NaiveDateTime>,
+        #[clap(
+            short,
+            long,
+            help = "Recurrence rule signaling repeating budget. Must pair with r_start if new"
+        )]
+        r_rule: Option<String>,
+    },
+    #[clap(about = "Update a budget line item")]
+    BudgetItem {
+        #[clap(help = "Id of the budget item")]
+        id: i32,
+        #[clap(short, long, help = "Id of the budget")]
+        budget_id: Option<i32>,
+        #[clap(short, long, help = "Name of the line item")]
+        name: Option<String>,
+        #[clap(short, long, help = "Description of the line item")]
+        description: Option<String>,
+        #[clap(short, long, help = "Value of this item")]
+        amount: Option<f32>,
+        #[clap(short='s', long, value_parser = crate::shared::parse_date, help = "Date budget recurrence starts (format: YYYY-MM-DD)")]
+        r_start: Option<chrono::NaiveDateTime>,
+        #[clap(
+            short,
+            long,
+            help = "Recurrence rule signaling repeating budget item. Must pair with r_start if new"
+        )]
+        r_rule: Option<String>,
+    },
+}
+
+#[derive(Debug, Parser)]
+pub struct UpdateArgs {
+    #[clap(subcommand)]
+    pub command: UpdateCommand,
+}
+
+pub fn handle_update_command(args: UpdateArgs, conn: SqliteConnection) {
+    match args.command {
+        UpdateCommand::Budget {
+            id,
+            name,
+            description,
+            anticipated_amount,
+            r_start,
+            r_rule,
+        } => {
+            if r_rule.is_some() || r_start.is_some() {
+                alert!("Validating recurrence rules");
+            };
+            match dto::update_budget(
+                conn,
+                id,
+                name,
+                description,
+                anticipated_amount,
+                r_start.map(|v| UnixTimestamp::new(v)),
+                r_rule.map(|v| RecurrenceRule::new(v)),
+            ) {
+                Ok(res) => success!("Updated budget: {} - {}", res.0, res.1),
+                Err(e) => {
+                    alert!("Failed to update budget");
+                    log::error!("Update Budget: {}", e);
+                }
+            }
+        }
+        UpdateCommand::BudgetItem {
+            id,
+            budget_id,
+            name,
+            description,
+            amount,
+            r_start,
+            r_rule,
+        } => {
+            if r_rule.is_some() || r_start.is_some() {
+                alert!("Validating recurrence rules");
+            };
+            match dto::update_budget_item(
+                conn,
+                id,
+                budget_id,
+                name,
+                description,
+                amount,
+                r_start.map(|v| UnixTimestamp::new(v)),
+                r_rule.map(|v| RecurrenceRule::new(v)),
+            ) {
+                Ok(res) => success!("Updated budget item: {} - {}", res.0, res.1),
+                Err(e) => {
+                    alert!("Failed to update budget");
+                    log::error!("Update Budget Item: {}", e);
+                }
+            }
+        }
+    }
+}

--- a/cli/src/update_command.rs
+++ b/cli/src/update_command.rs
@@ -74,8 +74,8 @@ pub fn handle_update_command(args: UpdateArgs, conn: SqliteConnection) {
                 name,
                 description,
                 anticipated_amount,
-                r_start.map(|v| UnixTimestamp::new(v)),
-                r_rule.map(|v| RecurrenceRule::new(v)),
+                r_start.map(UnixTimestamp::new),
+                r_rule.map(RecurrenceRule::new),
             ) {
                 Ok(res) => success!("Updated budget: {} - {}", res.0, res.1),
                 Err(e) => {
@@ -103,8 +103,8 @@ pub fn handle_update_command(args: UpdateArgs, conn: SqliteConnection) {
                 name,
                 description,
                 amount,
-                r_start.map(|v| UnixTimestamp::new(v)),
-                r_rule.map(|v| RecurrenceRule::new(v)),
+                r_start.map(UnixTimestamp::new),
+                r_rule.map(RecurrenceRule::new),
             ) {
                 Ok(res) => success!("Updated budget item: {} - {}", res.0, res.1),
                 Err(e) => {

--- a/cli/src/update_command/dto.rs
+++ b/cli/src/update_command/dto.rs
@@ -73,7 +73,7 @@ pub fn update_budget(
 
                 // Get the dt_start to validate against (new one or existing)
                 let dt_start_for_validation =
-                    r_start.clone().unwrap_or_else(|| current_recurrence.dt_start.clone());
+                    r_start.unwrap_or_else(|| current_recurrence.dt_start);
 
                 // Get the rrule to validate (new one or existing)
                 let mut rrule_to_validate =
@@ -150,7 +150,7 @@ pub fn update_budget_item(
 
                 // Get the dt_start to validate against (new one or existing)
                 let dt_start_for_validation =
-                    r_start.clone().unwrap_or_else(|| current_recurrence.dt_start.clone());
+                    r_start.unwrap_or_else(|| current_recurrence.dt_start);
 
                 // Get the rrule to validate (new one or existing)
                 let mut rrule_to_validate =

--- a/cli/src/update_command/dto.rs
+++ b/cli/src/update_command/dto.rs
@@ -1,0 +1,194 @@
+use crate::shared::{create_budget_recurrence, validate_rrule};
+use cobblepot_data_store::{RecurrenceRule, UnixTimestamp, schema};
+use diesel::{
+    AsChangeset, Connection, ExpressionMethods, Identifiable, QueryResult, SqliteConnection,
+};
+
+#[derive(Identifiable, AsChangeset)]
+#[diesel(check_for_backend(Sqlite))]
+#[diesel(table_name = schema::budget)]
+pub struct UpdateBudget {
+    pub id: i32,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub anticipated_amount: Option<f32>,
+}
+
+#[derive(Identifiable, AsChangeset)]
+#[diesel(table_name = schema::budget_recurrence)]
+pub struct UpdateBudgetRecurrence {
+    pub id: i32,
+    pub dt_start: Option<UnixTimestamp>,
+    pub recurrence_rule: Option<RecurrenceRule>,
+}
+
+#[derive(Identifiable, AsChangeset, Debug)]
+#[diesel(check_for_backend(Sqlite))]
+#[diesel(table_name = schema::budget_item)]
+pub struct UpdateBudgetItem {
+    pub id: i32,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub amount: Option<f32>,
+    pub budget_id: Option<i32>,
+}
+
+pub fn update_budget(
+    mut conn: SqliteConnection,
+    id: i32,
+    name: Option<String>,
+    description: Option<String>,
+    anticipated_amount: Option<f32>,
+    r_start: Option<UnixTimestamp>,
+    r_rule: Option<RecurrenceRule>,
+) -> QueryResult<(i32, String)> {
+    use cobblepot_data_store::Budget;
+    use diesel::{QueryDsl, RunQueryDsl};
+
+    conn.transaction(|conn| {
+        // Update budget if at least one field is provided, otherwise just fetch
+        let budget_updated = if name.is_some()
+            || description.is_some()
+            || anticipated_amount.is_some()
+        {
+            let budget_changeset = UpdateBudget {
+                id,
+                name,
+                description,
+                anticipated_amount,
+            };
+            diesel::update(&budget_changeset).set(&budget_changeset).get_result::<Budget>(conn)?
+        } else {
+            schema::budget::table.find(id).first(conn)?
+        };
+
+        // Update budget_recurrence if it exists and recurrence fields are provided
+        if let Some(rec_id) = budget_updated.budget_recurrence_id {
+            if r_start.is_some() || r_rule.is_some() {
+                use cobblepot_data_store::BudgetRecurrence;
+
+                // Fetch current recurrence to get existing values for validation
+                let current_recurrence: BudgetRecurrence =
+                    schema::budget_recurrence::table.find(rec_id).first(conn)?;
+
+                // Get the dt_start to validate against (new one or existing)
+                let dt_start_for_validation =
+                    r_start.clone().unwrap_or_else(|| current_recurrence.dt_start.clone());
+
+                // Get the rrule to validate (new one or existing)
+                let mut rrule_to_validate =
+                    r_rule.clone().unwrap_or_else(|| current_recurrence.recurrence_rule.clone());
+
+                // Validate the rrule against the dt_start
+                let validated = validate_rrule(&dt_start_for_validation, &mut rrule_to_validate);
+
+                let recurrence_changeset = UpdateBudgetRecurrence {
+                    id: rec_id,
+                    dt_start: r_start,
+                    recurrence_rule: if r_rule.is_some() {
+                        Some(validated)
+                    } else {
+                        None
+                    },
+                };
+                diesel::update(&recurrence_changeset).set(&recurrence_changeset).execute(conn)?;
+            }
+        } else if let Some((dt_start, rrule)) = r_start.zip(r_rule) {
+            // Create new recurrence
+            let rec_id =
+                create_budget_recurrence(conn, dt_start, rrule, Some(budget_updated.id), None)?;
+
+            // Update budget to point to the new recurrence
+            diesel::update(schema::budget::table.filter(schema::budget::id.eq(budget_updated.id)))
+                .set(schema::budget::budget_recurrence_id.eq(rec_id))
+                .execute(conn)?;
+        }
+
+        Ok((budget_updated.id, budget_updated.name))
+    })
+}
+
+pub fn update_budget_item(
+    mut conn: SqliteConnection,
+    id: i32,
+    budget_id: Option<i32>,
+    name: Option<String>,
+    description: Option<String>,
+    amount: Option<f32>,
+    r_start: Option<UnixTimestamp>,
+    r_rule: Option<RecurrenceRule>,
+) -> QueryResult<(i32, String)> {
+    use cobblepot_data_store::BudgetItem;
+    use diesel::{QueryDsl, RunQueryDsl};
+
+    conn.transaction(|conn| {
+        // Update budget_item if at least one field is provided, otherwise just fetch
+        let budget_item_updated =
+            if name.is_some() || description.is_some() || amount.is_some() || budget_id.is_some() {
+                let budget_item_changeset = UpdateBudgetItem {
+                    id,
+                    name,
+                    description,
+                    amount,
+                    budget_id,
+                };
+                diesel::update(&budget_item_changeset)
+                    .set(&budget_item_changeset)
+                    .get_result::<BudgetItem>(conn)?
+            } else {
+                schema::budget_item::table.find(id).first(conn)?
+            };
+
+        // Update budget_recurrence if it exists and recurrence fields are provided
+        if let Some(rec_id) = budget_item_updated.budget_recurrence_id {
+            if r_start.is_some() || r_rule.is_some() {
+                use cobblepot_data_store::BudgetRecurrence;
+
+                // Fetch current recurrence to get existing values for validation
+                let current_recurrence: BudgetRecurrence =
+                    schema::budget_recurrence::table.find(rec_id).first(conn)?;
+
+                // Get the dt_start to validate against (new one or existing)
+                let dt_start_for_validation =
+                    r_start.clone().unwrap_or_else(|| current_recurrence.dt_start.clone());
+
+                // Get the rrule to validate (new one or existing)
+                let mut rrule_to_validate =
+                    r_rule.clone().unwrap_or_else(|| current_recurrence.recurrence_rule.clone());
+
+                // Validate the rrule against the dt_start
+                let validated = validate_rrule(&dt_start_for_validation, &mut rrule_to_validate);
+
+                let recurrence_changeset = UpdateBudgetRecurrence {
+                    id: rec_id,
+                    dt_start: r_start,
+                    recurrence_rule: if r_rule.is_some() {
+                        Some(validated)
+                    } else {
+                        None
+                    },
+                };
+                diesel::update(&recurrence_changeset).set(&recurrence_changeset).execute(conn)?;
+            }
+        } else if let Some((dt_start, rrule)) = r_start.zip(r_rule) {
+            // Create new recurrence
+            let rec_id = create_budget_recurrence(
+                conn,
+                dt_start,
+                rrule,
+                None,
+                Some(budget_item_updated.id),
+            )?;
+
+            // Update budget_item to point to the new recurrence
+            diesel::update(
+                schema::budget_item::table
+                    .filter(schema::budget_item::id.eq(budget_item_updated.id)),
+            )
+            .set(schema::budget_item::budget_recurrence_id.eq(rec_id))
+            .execute(conn)?;
+        }
+
+        Ok((budget_item_updated.id, budget_item_updated.name))
+    })
+}

--- a/data_store/data_store.rs
+++ b/data_store/data_store.rs
@@ -69,7 +69,7 @@ pub struct BudgetItemAccount {
     pub allocation_percentage: Option<i32>,
 }
 
-#[derive(Debug, Queryable, Identifiable, Selectable, Serialize, Deserialize)]
+#[derive(Debug, Queryable, Identifiable, Selectable, Serialize, Deserialize, Clone)]
 #[diesel(check_for_backend(Sqlite))]
 #[diesel(table_name=schema::budget_recurrence)]
 pub struct BudgetRecurrence {

--- a/data_store/unix_timestamp.rs
+++ b/data_store/unix_timestamp.rs
@@ -31,9 +31,8 @@ where
 {
     fn from_sql(bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
         let timestamp = i32::from_sql(bytes)?;
-        let dt = DateTime::from_timestamp(timestamp as i64, 0)
-            .ok_or("Invalid timestamp")?
-            .naive_utc();
+        let dt =
+            DateTime::from_timestamp(timestamp as i64, 0).ok_or("Invalid timestamp")?.naive_utc();
         Ok(UnixTimestamp(dt))
     }
 }


### PR DESCRIPTION

## Summary

Introduce `update` subcommands to the CLI for budgets and budget items, and refactor recurrence logic into shared
helpers. This simplifies how recurrences are created, validated, and displayed, and makes recurrence behavior consistent
across creation, listing, and updating flows.

---

## Changes

- **CLI features**
  - Add `update` subcommands for:
    - `budget update`
    - `budget-item update`
  - Support updating:
    - Core fields (e.g., names, amounts, etc. as applicable)
    - Recurrence configuration (including optional creation of a recurrence if one does not yet exist)

- **Recurrence handling**
  - Centralize recurrence logic into shared helpers:
    - `create_budget_recurrence`
    - `validate_rrule`
    - `get_next_occurences`
    - `zip_all`
  - Apply shared recurrence logic to both budget and budget item flows.
  - Cap default recurrence `COUNT` at 30 to avoid unbounded recurrence expansion.
  - Improve budget item listing to include the next-occurrence information.

- **Code quality / maintenance**
  - Refactor budget and budget item creation and listing to use the new shared recurrence utilities.
  - Run `cargo fmt` and address `clippy` suggestions for consistent formatting and style.

---

## Motivation / Context

- Prior to this change, budgets and budget items could be created with recurrences but not easily updated via CLI.
- Recurrence logic was duplicated / scattered, increasing the risk of inconsistent behavior and bugs.
- Capping the default recurrence count and centralizing validation reduces unexpected performance issues and makes
  recurrence behavior more predictable.
- Exposing next occurrences in listings improves visibility into future budget items.

---
